### PR TITLE
Fixes to Receiving SMS Replies

### DIFF
--- a/application/classes/Controller/Sms/Twilio.php
+++ b/application/classes/Controller/Sms/Twilio.php
@@ -41,7 +41,7 @@ class Controller_Sms_Twilio extends Controller {
 			
 			// Use the last id of the ping to tag the pong
 			// TODO: Review
-			$ping = DB::select(array(DB::expr('COUNT(id)'), 'ping_id'))
+			$ping = DB::select(array(DB::expr('MAX(id)'), 'ping_id'))
 				->from('pings')
 				->where('contact_id', '=', $contact->id)
 				->where('type', '=', 'phone')
@@ -50,7 +50,7 @@ class Controller_Sms_Twilio extends Controller {
 				->as_array();
 			
 			// Record the pong
-			if ( count($ping) > 0 )
+			if ( $ping[0]['ping_id'] )
 			{
 				// Load the pong
 				$ping = ORM::factory('Ping', $ping[0]['ping_id']);

--- a/application/classes/PingApp/SMS/Provider/Twilio.php
+++ b/application/classes/PingApp/SMS/Provider/Twilio.php
@@ -27,7 +27,7 @@ class PingApp_SMS_Provider_Twilio extends Pingapp_SMS_Provider {
 		// Send!
 		try
 		{
-			$message = $this->_client->account->messages->sendMessage($from, $to, $message);
+			$message = $this->_client->account->messages->sendMessage($from, '+'.$to, $message);
 			return $message->sid;
 		}
 		catch (Services_Twilio_RestException $e)

--- a/application/migrations/1/20130927093959.php
+++ b/application/migrations/1/20130927093959.php
@@ -1,0 +1,26 @@
+<?php defined('SYSPATH') OR die('No direct script access.');
+
+class Migration_1_20130927093959 extends Minion_Migration_Base {
+
+	/**
+	 * Run queries needed to apply this migration
+	 *
+	 * @param Kohana_Database $db Database connection
+	 */
+	public function up(Kohana_Database $db)
+	{
+		$db->query(NULL, "ALTER TABLE `pings` CHANGE `status` `status` VARCHAR(20)  CHARACTER SET utf8  COLLATE utf8_general_ci  NOT NULL  DEFAULT 'pending'  COMMENT 'pending, received';");
+
+	}
+
+	/**
+	 * Run queries needed to remove this migration
+	 *
+	 * @param Kohana_Database $db Database connection
+	 */
+	public function down(Kohana_Database $db)
+	{
+		$db->query(NULL, "ALTER TABLE `pings` CHANGE `status` `status` VARCHAR(20)  CHARACTER SET utf8  COLLATE utf8_general_ci  NOT NULL  DEFAULT 'sent'  COMMENT 'unsent, sent, received';");
+	}
+
+}


### PR DESCRIPTION
- Since we're saving phone numbers as 'numeric' in the database we need to remove non-numeric characters before comparing any phone numbers
- We're also using strrpos to compare 'sender' and 'from' because some people might use '000-000-0000' in their sms config vs '+10000000000'. Both work. **strrpos** allows us to compare two numbers in case one doesn't have the country code. Twilio is obviously US biased.
- Append the '+' in the Twilio send() as the phone number is stored as numerical for consistency
- Reverted pings status column to 'pending/received'

@ekala -- need a review
